### PR TITLE
Combined termination criterion

### DIFF
--- a/utils/src/main/java/se/vti/utils/misc/metropolishastings/terminationcriteria/CombinedTerminationCriterion.java
+++ b/utils/src/main/java/se/vti/utils/misc/metropolishastings/terminationcriteria/CombinedTerminationCriterion.java
@@ -1,0 +1,87 @@
+// /**
+//  * se.vti.roundtrips.samplingweights.misc
+//  *
+//  * Copyright (C) 2025 by Gunnar Flötteröd (VTI, LiU).
+//  *
+//  * VTI = Swedish National Road and Transport Institute
+//  * LiU = Linköping University, Sweden
+//  *
+//  * This program is free software: you can redistribute it and/or modify it under the terms
+//  * of the GNU General Public License as published by the Free Software Foundation, either
+//  * version 3 of the License, or (at your option) any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  * See the GNU General Public License for more details.
+//  *
+//  * You should have received a copy of the GNU General Public License along with this program.
+//  * If not, see <https://www.gnu.org/licenses/>. See also COPYING and WARRANTY file.
+//  */
+
+package se.vti.utils.misc.metropolishastings.terminationcriteria;
+
+/**
+* @author MichaelS
+*/
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CombinedTerminationCriterion<X> implements TerminationCriterion<X> {
+    private final Logger logger = LogManager.getLogger(CombinedTerminationCriterion.class);
+    private final Set<TerminationCriterion<X>> terminationCriteria = new HashSet<>();
+
+    @SafeVarargs
+    public CombinedTerminationCriterion(TerminationCriterion<X>... terminationCriteria) {
+        for (TerminationCriterion<X> tc : terminationCriteria) {
+            this.terminationCriteria.add(tc);
+        }
+    }
+
+    public void addCriterion(TerminationCriterion<X> tc) {
+        this.terminationCriteria.add(tc);
+    }
+
+    @Override
+    public void start() {
+        for (TerminationCriterion<X> tc : this.terminationCriteria) {
+            tc.start();
+        }
+    }
+
+    @Override
+    public void processState(X state, double logWeight) {
+        for (TerminationCriterion<X> tc : this.terminationCriteria) {
+            tc.processState(state, logWeight);
+        }
+    }
+
+    @Override
+    public void end() {
+        for (TerminationCriterion<X> tc : this.terminationCriteria) {
+            tc.end();
+        }
+    }
+
+    @Override
+    public boolean terminate() {
+        for (TerminationCriterion<X> tc : this.terminationCriteria) {
+            if (tc.terminate()) {
+                logger.info("Termination triggered by criterion {}", tc.getClass());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void processState(X state) {
+        for (TerminationCriterion<X> tc : this.terminationCriteria) {
+            tc.processState(state);
+        }
+    }
+}

--- a/utils/src/main/java/se/vti/utils/misc/metropolishastings/terminationcriteria/TimeLimitTerminationCriterion.java
+++ b/utils/src/main/java/se/vti/utils/misc/metropolishastings/terminationcriteria/TimeLimitTerminationCriterion.java
@@ -1,0 +1,55 @@
+// /**
+//  * se.vti.roundtrips.samplingweights.misc
+//  *
+//  * Copyright (C) 2025 by Gunnar Flötteröd (VTI, LiU).
+//  *
+//  * VTI = Swedish National Road and Transport Institute
+//  * LiU = Linköping University, Sweden
+//  *
+//  * This program is free software: you can redistribute it and/or modify it under the terms
+//  * of the GNU General Public License as published by the Free Software Foundation, either
+//  * version 3 of the License, or (at your option) any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  * See the GNU General Public License for more details.
+//  *
+//  * You should have received a copy of the GNU General Public License along with this program.
+//  * If not, see <https://www.gnu.org/licenses/>. See also COPYING and WARRANTY file.
+//  */
+
+package se.vti.utils.misc.metropolishastings.terminationcriteria;
+
+/**
+* @author MichaelS
+*/
+
+public class TimeLimitTerminationCriterion<X> implements TerminationCriterion<X> {
+
+    private final double maxTime_s;
+    private double startTime_s;
+    private double now;
+
+    public TimeLimitTerminationCriterion(double maxTime_s) {
+        this.maxTime_s = maxTime_s;
+    }
+
+    @Override
+    public void start() {
+        startTime_s = System.currentTimeMillis() / 1000;
+    }
+
+    @Override
+    public void processState(X state) {
+        now = System.currentTimeMillis()  / 1000;
+    }
+
+    @Override
+    public void end() {
+    }
+
+    @Override
+    public boolean terminate() {
+        return (now - startTime_s >= maxTime_s);
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds two new `TerminationCriterion` implementations for the Metropolis-Hastings utilities:

* `CombinedTerminationCriterion`
* `TimeLimitTerminationCriterion`

## Changes

### `CombinedTerminationCriterion`

* Combines multiple termination criteria into one.
* Terminates when any [OR] contained criterion returns `true`.
* Logs which criterion triggered termination.

### `TimeLimitTerminationCriterion`

* Adds wall-clock time based termination.
* Stops execution after a configurable runtime limit (seconds).
* Uses `System.currentTimeMillis()` to track elapsed time.

## Use

```java
CombinedTerminationCriterion<MyState> criterion =
        new CombinedTerminationCriterion<>(
                new TimeLimitTerminationCriterion<>(60),
                new SomeOtherCriterion<>()
        );
```